### PR TITLE
chore: update to anoncreds-rs version 0.2.2

### DIFF
--- a/.changeset/public-plums-tease.md
+++ b/.changeset/public-plums-tease.md
@@ -3,4 +3,4 @@
 "@hyperledger/anoncreds-react-native": patch
 ---
 
-chore: update to anoncreds-rs version 0.2.1. This release adds support for 16KB page sizes on Android.
+chore: update to anoncreds-rs version 0.2.2. This release adds support for 16KB page sizes on Android.

--- a/packages/anoncreds-nodejs/package.json
+++ b/packages/anoncreds-nodejs/package.json
@@ -37,7 +37,7 @@
     "typescript": "catalog:"
   },
   "binary": {
-    "version": "v0.2.1",
+    "version": "v0.2.2",
     "host": "https://github.com/hyperledger/anoncreds-rs/releases/download",
     "packageName": "library-{platform}-{arch}.tar.gz"
   },

--- a/packages/anoncreds-react-native/package.json
+++ b/packages/anoncreds-react-native/package.json
@@ -49,7 +49,7 @@
     "react-native": ">= 0.71"
   },
   "binary": {
-    "version": "v0.2.1",
+    "version": "v0.2.2",
     "host": "https://github.com/hyperledger/anoncreds-rs/releases/download",
     "packageName": "library-ios-android.tar.gz"
   }


### PR DESCRIPTION
New anoncreds version adds support for 16kb page size. CI is currenlty running for anoncreds-rs, so release should become available soon-ish