### PR TITLE
fix: remove jcenter in android build

### DIFF
--- a/packages/anoncreds-react-native/android/build.gradle
+++ b/packages/anoncreds-react-native/android/build.gradle
@@ -4,7 +4,6 @@ import java.nio.file.Paths
 buildscript {
   repositories {
     google()
-    jcenter()
     mavenCentral()
   }
 


### PR DESCRIPTION
jcenter() method has been removed since Gradle 9, which is used by React Native 0.83 and therefore throws an error when attempting to do an Android build.